### PR TITLE
Issue #1 testGetLastTradedPrice() resolved

### DIFF
--- a/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
+++ b/src/test/java/org/galatea/starter/entrypoint/IexRestControllerTest.java
@@ -60,13 +60,13 @@ public class IexRestControllerTest extends ASpringTest {
 
     MvcResult result = this.mvc.perform(
         org.springframework.test.web.servlet.request.MockMvcRequestBuilders
-            .get("/iex/lastTradedPrice?symbols=AAPL")
+            .get("/iex/lastTradedPrice?symbols=FB")
             // This URL will be hit by the MockMvc client. The result is configured in the file
             // src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
             .accept(MediaType.APPLICATION_JSON_VALUE))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].symbol", is("FB")))
-        .andExpect(jsonPath("$[0].price").value(new BigDecimal("186.34")))
+        .andExpect(jsonPath("$[0].price").value(new BigDecimal("186.3011")))
         .andReturn();
   }
 

--- a/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
+++ b/src/test/resources/wiremock/mappings/mapping-lastTradedPrice.json
@@ -6,7 +6,7 @@
     "method" : "GET"
   },
   "response" : {
-    "status" : 404,
+    "status" : 200,
     "jsonBody" : [{"symbol":"FB","price":186.3011,"size":100,"time":1565273330617}],
     "headers" : {
       "Server" : "nginx",


### PR DESCRIPTION
testGetLastTradedPrice() executed without failure. Resolved the test failure by editing the test and WireMock file. Test previously failed for the following reasons:
-Stock symbol should be FB instead of AAPL in testGetLastTradedPrice().
-Price of FB should match in the test and WireMock file.
-Response status in the WireMock file should be 200.